### PR TITLE
feat: implement unified Vertex AI authentication system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,8 @@ api/.env*
 # Firebase Admin SDK service account key
 my-portfolio-menno-firebase-adminsdk-fbsvc-be51664a5d.json
 
-# Google Cloud service account key
+# Google Cloud service account keys (wildcard pattern to catch all)
+my-portfolio-menno-*.json
 my-portfolio-menno-1c10fc787618.json
+service-account-key-single-line.json
 .env.local

--- a/src/lib/load-service-account-key.ts
+++ b/src/lib/load-service-account-key.ts
@@ -1,0 +1,38 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * Ensures GOOGLE_APPLICATION_CREDENTIALS is set to a valid file for VertexAI/GoogleAuth.
+ * - Always writes GOOGLE_SERVICE_ACCOUNT_KEY to /tmp/gcp-sa-key.json and sets the env var if present.
+ * - If GOOGLE_SERVICE_ACCOUNT_KEY is not set, does nothing (assumes GOOGLE_APPLICATION_CREDENTIALS is set).
+ */
+export function loadServiceAccountKey() {
+  if (process.env.GOOGLE_SERVICE_ACCOUNT_KEY) {
+    const tempPath = "/tmp/gcp-sa-key.json";
+    // Log the first 100 chars of the env var
+    console.log("[loadServiceAccountKey] GOOGLE_SERVICE_ACCOUNT_KEY (first 100 chars):", process.env.GOOGLE_SERVICE_ACCOUNT_KEY.slice(0, 100));
+    
+    // Parse the JSON and properly format the private key
+    try {
+      const serviceAccountData = JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT_KEY);
+      // Replace escaped newlines with actual newlines in the private key
+      if (serviceAccountData.private_key) {
+        serviceAccountData.private_key = serviceAccountData.private_key.replace(/\\n/g, '\n');
+      }
+      const formattedJson = JSON.stringify(serviceAccountData, null, 2);
+      fs.writeFileSync(tempPath, formattedJson);
+      
+      // Log the first 100 chars of the written file
+      const written = fs.readFileSync(tempPath, "utf8");
+      console.log("[loadServiceAccountKey] /tmp/gcp-sa-key.json (first 100 chars):", written.slice(0, 100));
+      console.log("[loadServiceAccountKey] private_key starts with:", serviceAccountData.private_key.slice(0, 50));
+    } catch (parseError) {
+      console.error("[loadServiceAccountKey] Failed to parse GOOGLE_SERVICE_ACCOUNT_KEY:", parseError);
+      // Fallback: write as-is
+      fs.writeFileSync(tempPath, process.env.GOOGLE_SERVICE_ACCOUNT_KEY);
+    }
+    
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = tempPath;
+  }
+  // If GOOGLE_SERVICE_ACCOUNT_KEY is not set, assumes GOOGLE_APPLICATION_CREDENTIALS is set in .env.local or environment.
+}


### PR DESCRIPTION
- Add loadServiceAccountKey() utility for consistent auth across all endpoints
- Support both local development and Vercel deployment environments
- Fix OpenSSL decoder errors by properly formatting private keys
- Update .gitignore to prevent service account keys from being committed
- Add runtime logging for debugging authentication issues
- Unify authentication approach across /api/chat, /api/ai-chat, and /api/ai endpoints

Resolves authentication issues with Google Cloud Vertex AI integration.

## 🔧 Fix: Unified Vertex AI Authentication System

### Problem
- Multiple authentication errors across Vertex AI endpoints
- OpenSSL decoder errors with service account keys  
- Inconsistent authentication between local and Vercel environments
- Security risk of committing service account keys

### Solution
- ✅ Created unified `loadServiceAccountKey()` utility
- ✅ Fixed private key formatting (escaped newlines → actual newlines)
- ✅ Unified authentication across all 3 endpoints: `/api/chat`, `/api/ai-chat`, `/api/ai`
- ✅ Enhanced `.gitignore` to prevent credential commits
- ✅ Added runtime logging for debugging

### Testing
- ✅ All endpoints now authenticate successfully
- ✅ Works in both local development and Vercel deployment
- ✅ No sensitive files committed to repository

### Breaking Changes
None - backwards compatible implementation